### PR TITLE
Allow UTF8 in tests/run/annotate_html.pyx

### DIFF
--- a/tests/run/annotate_html.pyx
+++ b/tests/run/annotate_html.pyx
@@ -1,11 +1,12 @@
 """
+>>> from codecs import open
 >>> import os.path as os_path
 >>> module_path = os_path.join(os_path.dirname(__file__), os_path.basename(__file__).split('.', 1)[0])
 >>> assert module_path.endswith('annotate_html')
 >>> assert os_path.exists(module_path + '.c') or os_path.exists(module_path + '.cpp'), module_path
 >>> assert os_path.exists(module_path + '.html'), module_path
 
->>> with open(module_path + '.html') as html_file:
+>>> with open(module_path + '.html', 'r', 'utf8') as html_file:
 ...     html = html_file.read()
 
 >>> import re


### PR DESCRIPTION
Otherwise tests are failing on my box with a UnicodeDecodeError.

```
======================================================================
FAIL: annotate_html ()
Doctest: annotate_html
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/engshare/third-party2/python/3.5.0/gcc-4.9-glibc-2.20/cb5a762/lib/python3.5/doctest.py", line 2190, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for annotate_html
  File "/home/engshare/third-party2/Cython/master/src/build-gcc-4.9-glibc-2.20/build/TEST_TMP/0/run/c/annotate_html/annotate_html.cpython-35m-x86_64-linux-gnu.so", line 1, in annotate_html

----------------------------------------------------------------------
File "/home/engshare/third-party2/Cython/master/src/build-gcc-4.9-glibc-2.20/build/TEST_TMP/0/run/c/annotate_html/annotate_html.cpython-35m-x86_64-linux-gnu.so", line 9, in annotate_html
Failed example:
    with open(module_path + '.html') as html_file:
        html = html_file.read()
Exception raised:
    Traceback (most recent call last):
      File "/home/engshare/third-party2/python/3.5.0/gcc-4.9-glibc-2.20/cb5a762/lib/python3.5/doctest.py", line 1321, in __run
        compileflags, 1), test.globs)
      File "<doctest annotate_html[5]>", line 2, in <module>
        html = html_file.read()
      File "/home/engshare/third-party2/python/3.5.0/gcc-4.9-glibc-2.20/cb5a762/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 16904: ordinal not in range(128)
----------------------------------------------------------------------
File "/home/engshare/third-party2/Cython/master/src/build-gcc-4.9-glibc-2.20/build/TEST_TMP/0/run/c/annotate_html/annotate_html.cpython-35m-x86_64-linux-gnu.so", line 13, in annotate_html
Failed example:
    assert re.search('<pre .*def.* .*mixed_test.*</pre>', html)
Exception raised:
    Traceback (most recent call last):
      File "/home/engshare/third-party2/python/3.5.0/gcc-4.9-glibc-2.20/cb5a762/lib/python3.5/doctest.py", line 1321, in __run
        compileflags, 1), test.globs)
      File "<doctest annotate_html[7]>", line 1, in <module>
        assert re.search('<pre .*def.* .*mixed_test.*</pre>', html)
    NameError: name 'html' is not defined
```